### PR TITLE
Handle trigger rejects

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,11 @@ function start({recipes, triggers, useParentCorrelationId}) {
   const handleFlowMessage = buildFlowHandler(recipeMap);
   const handleTriggerMessage = buildTriggerHandler(recipeMap, useParentCorrelationId);
   const handleRejectMessage = buildRejectHandler();
-  crd.subscribe(recipeMap.keys(), lambdasQueueName, handleMessageWrapper(handleFlowMessage));
-  crd.subscribe(recipeMap.triggerKeys(), triggersQueueName, handleMessageWrapper(handleTriggerMessage));
-  reject.subscribe(recipeMap.keys(), rejectQueueName, handleMessageWrapper(handleRejectMessage));
+  const flowKeys = recipeMap.keys();
+  const triggerKeys = recipeMap.triggerKeys();
+  crd.subscribe(flowKeys, lambdasQueueName, handleMessageWrapper(handleFlowMessage));
+  crd.subscribe(triggerKeys, triggersQueueName, handleMessageWrapper(handleTriggerMessage));
+  reject.subscribe([...flowKeys, ...triggerKeys], rejectQueueName, handleMessageWrapper(handleRejectMessage));
 }
 
 function handleMessageWrapper(fn) {

--- a/lib/handle-flow-message.js
+++ b/lib/handle-flow-message.js
@@ -31,6 +31,7 @@ function buildFlowHandler(recipes) {
 
     if (!handlerFunction) {
       return rejectMessage(
+        broker.lambdasQueueName,
         `No handler for routing key: ${routingKey}, message: ${JSON.stringify(message)}`,
         message,
         context,
@@ -76,7 +77,7 @@ function buildFlowHandler(recipes) {
       return notify.ack();
     } catch (err) {
       if (err.rejected || err.unrecoverable) {
-        return rejectMessage(err, message, context, meta, notify);
+        return rejectMessage(broker.lambdasQueueName, err, message, context, meta, notify);
       }
       return retryMessage(err, message, context, notify);
     } finally {

--- a/lib/handle-trigger-message.js
+++ b/lib/handle-trigger-message.js
@@ -25,7 +25,9 @@ function buildTriggerHandler(recipes, useParentCorrelationId) {
         generic(useParentCorrelationId || recipes.genericTriggerUsesParentCorrelationId(routingKey));
 
       const calculatedResponse = fn(source, context);
-      const responses = Array.isArray(calculatedResponse) ? calculatedResponse : [calculatedResponse];
+      const responses = calculatedResponse
+        ? (Array.isArray(calculatedResponse) && calculatedResponse) || [calculatedResponse]
+        : [];
       if (responses.length === 0) logger.info(`Trigger nothing for source ${JSON.stringify(source)}`);
       for (const response of responses) {
         if (response.type !== "trigger") throw new Error(`Invalid format for response ${JSON.stringify(response)}`);
@@ -57,7 +59,7 @@ function buildTriggerHandler(recipes, useParentCorrelationId) {
         logger.info(`Triggered ${first} from ${routingKey} with source ${JSON.stringify(source)}`);
       }
     } catch (err) {
-      return rejectMessage(err, source, context, meta, notify);
+      return rejectMessage(broker.triggersQueueName, err, source, context, meta, notify);
     } finally {
       activeHandlers.dec();
     }

--- a/lib/reject-message.js
+++ b/lib/reject-message.js
@@ -2,10 +2,10 @@
 
 const bugsnag = require("bugsnag");
 const caller = require("./caller");
-const {reject, lambdasQueueName} = require("./broker");
+const {reject} = require("./broker");
 const config = require("exp-config");
 
-async function rejectMessage(error, message, context, meta, notify) {
+async function rejectMessage(queue, error, message, context, meta, notify) {
   const {logger, routingKey} = context;
   const verboseError = buildError(error, caller());
   message.errors = message.errors || [];
@@ -26,7 +26,7 @@ async function rejectMessage(error, message, context, meta, notify) {
           {
             count: 1,
             exchange: config.rabbit.exchange,
-            queue: lambdasQueueName,
+            queue: queue,
             reason: "rejected",
             "routing-keys": [context.routingKey],
             time: {
@@ -36,7 +36,7 @@ async function rejectMessage(error, message, context, meta, notify) {
           }
         ],
         "x-first-death-exchange": config.rabbit.exchange,
-        "x-first-death-queue": lambdasQueueName,
+        "x-first-death-queue": queue,
         "x-first-death-reason": "rejected",
         "x-routing-key": context.routingKey
       }
@@ -45,10 +45,10 @@ async function rejectMessage(error, message, context, meta, notify) {
   );
 }
 
-function buildError(error) {
+function buildError(error, source) {
   return {
-    status: error.code,
-    source: error.source,
+    status: error.code || null,
+    source: error.source || source,
     title: error.message
   };
 }

--- a/test/feature/reject-message-feature.js
+++ b/test/feature/reject-message-feature.js
@@ -79,6 +79,75 @@ Feature("Reject message", () => {
     });
   });
 
+  Scenario("Rejecting a trigger message", () => {
+    before(() => {
+      crd.resetMock();
+      reject.resetMock();
+      start({
+        triggers: {
+          "trigger.some-name": () => {
+            throw Error("got that wrong");
+          }
+        },
+        recipes: [
+          {
+            namespace: "event",
+            name: "some-name",
+            sequence: [route(".perform.one", rejectHandler)]
+          }
+        ]
+      });
+    });
+    let rejectedMessages;
+
+    Given("we are listening for messages on the event namespace", () => {
+      rejectedMessages = reject.subscribe("#");
+    });
+
+    When("we publish an order on a trigger key", async () => {
+      await crd.publishMessage("trigger.some-name", source);
+    });
+
+    Then("the trigger message should be rejected", () => {
+      rejectedMessages.length.should.eql(1);
+      rejectedMessages[0].key.should.eql("trigger.some-name");
+    });
+
+    And("the message should be acked and be the same as the rejected message", () => {
+      crd.ackedMessages[0].should.eql(rejectedMessages[0].msg);
+    });
+
+    And("the reject queue should have a nacked message", () => {
+      reject.nackedMessages.should.have.length(1);
+      reject.nackedMessages[0].should.eql(rejectedMessages[0].msg);
+    });
+
+    And("the rejected message should not longer have a reject key", () => {
+      rejectedMessages[0].meta.properties.should.not.have.property("type");
+    });
+
+    And("the rejected message should have x-death set", () => {
+      rejectedMessages[0].meta.properties.headers.should.have.property("x-death");
+    });
+    And("the rejected message should have the expected x-death", () => {
+      const [xDeath] = rejectedMessages[0].meta.properties.headers["x-death"];
+      xDeath.should.eql({
+        count: 1,
+        exchange: "CRDExchangeTest",
+        queue: "lu-broker-triggers-test",
+        reason: "rejected",
+        "routing-keys": ["trigger.some-name"],
+        time: xDeath.time
+      });
+    });
+    And("the rejected message should have x-routing-key set", () => {
+      rejectedMessages[0].meta.properties.headers.should.have.property("x-routing-key", "trigger.some-name");
+    });
+    And("the rejected message should have correct routingKey", () => {
+      rejectedMessages[0].meta.fields.routingKey.should.eql("trigger.some-name");
+    });
+  });
+
   Scenario("Rejecting a message in a flow preserving headers", () => {
     before(() => {
       crd.resetMock();


### PR DESCRIPTION
* Don't crash with type error when trigger is rejected
* Reject handler listens to flow keys and trigger keys
* When rejecting message pass along the actual queue and do not default
  to the lambda queue