### PR TITLE
Do not touch source meta

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,8 @@
+{
+  "timeout": 3000,
+  "reporter": "spec",
+  "recursive": true,
+  "ui": "mocha-cakes-2",
+  "exit": true,
+  "require": ["./test/helpers/setup.js"]
+}

--- a/lib/context.js
+++ b/lib/context.js
@@ -20,16 +20,27 @@ function context(message, meta) {
   const routingKey = getRoutingKey(meta);
   const replyToKey = getReplyToKey(meta);
   const app = packageInfo.name;
-  correlation.ensureMessageCorrelation(message);
+  correlation.ensureMessageCorrelation(message, meta);
   const debugMeta = {meta: {...message.meta, routingKey, replyToKey, retryCount, app}};
   const http = httpClient(debugMeta);
+  const logger = buildLogger(debugMeta);
 
+  if (
+    meta &&
+    meta.properties &&
+    meta.properties.correlationId &&
+    meta.properties.correlationId !== message.meta.correlationId
+  ) {
+    logger.error(
+      `Got one correlationId in message (${message.meta.correlationId}) and another in the AMQP property (${meta.properties.correlationId})`
+    );
+  }
   return {
     message,
     debugMeta,
-    correlationId: message.meta.correlationId,
+    correlationId: (meta && meta.properties && meta.properties.correlationId) || message.meta.correlationId,
     routingKey,
-    logger: buildLogger(debugMeta),
+    logger,
     http,
     findAttribute,
     findOrReject: findOrReject.bind(findOrReject, rejectUnless),

--- a/lib/correlation.js
+++ b/lib/correlation.js
@@ -2,9 +2,10 @@
 
 const uuid = require("uuid");
 
-function ensureMessageCorrelation(msg) {
+function ensureMessageCorrelation(msg, meta) {
   if (!msg.meta) msg.meta = {};
-  if (!msg.meta.correlationId) msg.meta.correlationId = uuid.v4();
+  if (!msg.meta.correlationId)
+    msg.meta.correlationId = (meta && meta.properties && meta.properties.correlationId) || uuid.v4();
 
   return msg;
 }

--- a/lib/handle-flow-message.js
+++ b/lib/handle-flow-message.js
@@ -114,13 +114,11 @@ function buildFlowHandler(recipes) {
     }
 
     sources.forEach(async (source, index) => {
-      const newMeta = {
-        ...source.meta,
-        notifyProcessed: `${context.routingKey}:${context.correlationId}`,
-        correlationId: `${context.correlationId}:${index}`,
-        parentCorrelationId: context.correlationId
-      };
-      await publish(`trigger.${response.id}`, {...source, meta: newMeta}, meta, context);
+      if (!meta.properties.headers) meta.properties.headers = {};
+      meta.properties.headers["x-notify-processed"] = `${context.routingKey}:${context.correlationId}`;
+      meta.properties.correlationId = `${context.correlationId}:${index}`;
+      meta.properties.headers["x-parent-correlation-id"] = context.correlationId;
+      await publish(`trigger.${response.id}`, source, meta, context);
     });
   }
 
@@ -128,11 +126,12 @@ function buildFlowHandler(recipes) {
     if (!message) return;
     const headers = meta.properties.headers || {};
     delete headers["x-routing-key"];
+
     return await broker.crd.publishMessage(
       responseKey,
       message,
       {
-        correlationId: context.correlationId,
+        correlationId: meta.properties.correlationId || context.correlationId,
         headers,
         replyTo: recipes.next(responseKey)
       },

--- a/lib/handle-trigger-message.js
+++ b/lib/handle-trigger-message.js
@@ -52,9 +52,19 @@ function buildTriggerHandler(recipes, useParentCorrelationId) {
         // This format is superstrange but:
         // if you decide to put correlationId directly on the message instead of under "meta",
         // let it override the correlationId given in meta
-        newMeta.correlationId = response.correlationId || newMeta.correlationId || context.correlationId;
-        if (response.correlationId) newMeta.parentCorrelationId = context.correlationId;
+        newMeta.correlationId = response.correlationId || context.correlationId;
 
+        const parentCorrelationId = response.correlationId
+          ? context.correlationId
+          : meta && meta.properties && meta.properties.headers && meta.properties.headers["x-parent-correlation-id"];
+
+        if (parentCorrelationId) {
+          newMeta.parentCorrelationId = parentCorrelationId;
+        }
+        // get some message meta stuff from the headers
+        const notifyProcessed =
+          meta && meta.properties && meta.properties.headers && meta.properties.headers["x-notify-processed"];
+        newMeta.notifyProcessed = notifyProcessed;
         const message = {
           type: namespace,
           id: uuid.v4(),
@@ -62,11 +72,12 @@ function buildTriggerHandler(recipes, useParentCorrelationId) {
           meta: newMeta,
           source: response.source
         };
+
         await broker.crd.publishMessage(
           first,
           message,
           {
-            correlationId: context.correlationId,
+            correlationId: newMeta.correlationId,
             replyTo: recipes.next(first)
           },
           context.debugMeta
@@ -96,6 +107,7 @@ function generic(useParentCorrelationId) {
         id: source.id,
         type: source.type,
         attributes: source.attributes,
+        meta: source.meta,
         relationships: source.relationships, // legacy compatability for v1 entities
         externalIds: source.externalIds // legacy compatability for v1 entities
       }

--- a/test/feature/http-trigger-feature.js
+++ b/test/feature/http-trigger-feature.js
@@ -70,7 +70,7 @@ Feature("Trigger via http", () => {
             key: "event.some-name.perform.one"
           }
         ],
-        source: {id: source.id, type: source.type, attributes: source.attributes},
+        source: {id: source.id, type: source.type, attributes: source.attributes, meta: source.meta},
         meta: {
           correlationId: "trigger-via-http-correlation"
         }

--- a/test/feature/sequence-feature.js
+++ b/test/feature/sequence-feature.js
@@ -80,7 +80,7 @@ Feature("Lamda functions", () => {
             key: "event.some-name.perform.one"
           }
         ],
-        source: {id: source.id, type: source.type, attributes: source.attributes},
+        source: {id: source.id, type: source.type, attributes: source.attributes, meta: source.meta},
         meta: {
           correlationId: "some-correlation-id"
         }
@@ -200,7 +200,7 @@ Feature("Lamda functions", () => {
             key: "event.the-coolest-event-ever.perform.three"
           }
         ],
-        source: {id: source.id, type: source.type, attributes: source.attributes},
+        source: {id: source.id, type: source.type, attributes: source.attributes, meta: source.meta},
         meta: {
           correlationId: "some-correlation-id"
         }
@@ -271,7 +271,7 @@ Feature("Lamda functions", () => {
             key: "event.first.perform.three"
           }
         ],
-        source: {id: source.id, type: source.type, attributes: source.attributes},
+        source: {id: source.id, type: source.type, attributes: source.attributes, meta: source.meta},
         meta: {
           correlationId: "some-correlation-id"
         }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,0 @@
---timeout 2000
---reporter spec
---recursive
---ui mocha-cakes-2
---exit
---require ./test/helpers/setup.js


### PR DESCRIPTION
Make a distinction between the source meta and the message meta, i.e.
parentCorrelationId and notifyProcessed are not properties of the source
but of the message (in the case of spawning). Transfer the (internal)
message properties using headers (`x-notify-processed` and
`x-parent-correlation-id`).

Also use the message property (AMQP native) correlationId as context
correlationId when available.