### PR TITLE
Handle unrecoverable spawned children

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,11 @@ function start({recipes, triggers, useParentCorrelationId}) {
   crd.subscribe(triggerKeys, triggersQueueName, handleMessageWrapper(handleTriggerMessage));
   reject.subscribe([...flowKeys, ...triggerKeys], rejectQueueName, handleMessageWrapper(handleRejectMessage));
 
-  internal.subscribe(recipeMap.processedKeys(), internalQueueName, handleMessageWrapper(handleInteralMessage));
+  internal.subscribe(
+    [...recipeMap.processedKeys(), ...recipeMap.processedUnrecoverableKeys()],
+    internalQueueName,
+    handleMessageWrapper(handleInteralMessage)
+  );
 
   const routes = require("./lib/server/routes")(triggerKeys);
   server = require("./lib/server/http-server")(routes);

--- a/lib/recipe-repo.js
+++ b/lib/recipe-repo.js
@@ -150,6 +150,7 @@ function init(recipes, triggers = {}) {
     next: (replyKey) => recipeMap[replyKey],
     keys: () => recipes.map((r) => `${r.namespace}.${r.name}.#`),
     processedKeys: () => recipes.map((r) => `${r.namespace}.${r.name}.processed`),
+    processedUnrecoverableKeys: () => Object.keys(unrecoverableMap).map((k) => `${k}.unrecoverable.processed`),
     triggerKeys: () => triggerKeys,
     triggerHandler: (routingKey) => triggers[routingKey],
     genericTriggerUsesParentCorrelationId: (routingKey) => useParentCorrelationIdMap[routingKey],

--- a/test/feature/spawn-feature.js
+++ b/test/feature/spawn-feature.js
@@ -305,4 +305,128 @@ Feature("Spawn flows with triggers", () => {
       result.should.eql([0, 4, 3, 2]);
     });
   });
+
+  Scenario("One child is unrecoverable", () => {
+    const unrecoverable = [];
+    function handleUnrecoverable(error, message, context) {
+      unrecoverable.push({error, message, routingKey: context.routingKey});
+      return {type: "some-type", id: "some-id"};
+    }
+    const result = [];
+    let tries = 0;
+    function addWithDelay(i, delay = 0) {
+      return async () => {
+        await sleep(delay);
+        result.push(i);
+        return {type: "baz", id: `my-guid-${i}`};
+      };
+    }
+    function addWithTry(i, delay = 0) {
+      return async (message, {unrecoverableIf}) => {
+        unrecoverableIf(message.meta.correlationId === "some-order-correlation-id:1", "this is a bad order");
+        tries = tries + 10;
+        const newDelay = delay + tries;
+        await sleep(newDelay);
+        result.push(i);
+        return {type: "baz", id: `my-try-${newDelay}`};
+      };
+    }
+
+    before(() => {
+      crd.resetMock();
+      start({
+        recipes: [
+          {
+            namespace: "event",
+            name: "some-name",
+            sequence: [
+              route(".perform.first", addWithDelay(0, 1)),
+              route(".perform.one", triggerMultiple),
+              route(".perform.two", addWithDelay(2, 1))
+            ]
+          },
+          {
+            namespace: "sub-sequence",
+            name: "some-sub-name",
+            sequence: [route(".perform.one", addWithTry(1, 5))],
+            unrecoverable: [route("*", handleUnrecoverable)]
+          }
+        ]
+      });
+    });
+
+    let flowMessages, subFlowMessages, donePromise, triggerMessages;
+    Given("we are listening for messages on the event namespace", () => {
+      flowMessages = crd.subscribe("event.some-name.#");
+      subFlowMessages = crd.subscribe("sub-sequence.some-sub-name.#");
+      donePromise = new Promise((resolve) => crd.subscribe("event.some-name.processed", resolve));
+    });
+
+    When("we publish an order on the other events a trigger key", async () => {
+      await crd.publishMessage("trigger.event.some-name", source);
+      triggerMessages = crd.subscribe("trigger.#");
+    });
+
+    Then("we should get 2 trigger messages", () => {
+      triggerMessages.should.have.length(2);
+    });
+
+    And("the last one should be the last source message", () => {
+      triggerMessages
+        .map(({msg}) => msg)
+        .should.eql([
+          {
+            ...source
+          },
+          {
+            ...source2
+          }
+        ]);
+    });
+
+    And("the trigger messages should carry parent correlation ids and such using headers", () => {
+      triggerMessages[0].meta.properties.correlationId.should.eql(`${source.meta.correlationId}:0`);
+      triggerMessages[0].meta.properties.headers["x-parent-correlation-id"].should.eql(source.meta.correlationId);
+      triggerMessages[0].meta.properties.headers["x-notify-processed"].should.eql(
+        `event.some-name.perform.one:${source.meta.correlationId}`
+      );
+      triggerMessages[1].meta.properties.correlationId.should.eql(`${source.meta.correlationId}:1`);
+      triggerMessages[1].meta.properties.headers["x-parent-correlation-id"].should.eql(source.meta.correlationId);
+      triggerMessages[1].meta.properties.headers["x-notify-processed"].should.eql(
+        `event.some-name.perform.one:${source.meta.correlationId}`
+      );
+    });
+
+    And("the parent flow should be completed", async () => {
+      await donePromise;
+      flowMessages.length.should.eql(4);
+      const {msg, key} = flowMessages.pop();
+      key.should.eql("event.some-name.processed");
+      msg.data
+        .map(({type, id, times}) => ({type, id, times}))
+        .should.eql([
+          {type: "baz", id: "my-guid-0", times: undefined},
+          {type: "trigger", id: "sub-sequence.some-sub-name", times: 2},
+          {type: "baz", id: "my-guid-2", times: undefined}
+        ]);
+    });
+
+    And("the 2 child flows should be completed", async () => {
+      await donePromise;
+      subFlowMessages.length.should.eql(4);
+      subFlowMessages
+        .filter(({key}) => key === "sub-sequence.some-sub-name.processed")
+        .map(({msg}) => msg.data)
+        .forEach((data, idx) => {
+          data.map(({type, id}) => ({type, id})).should.eql([{type: "baz", id: `my-try-${idx * 10 + 15}`}]); // not ok!
+        });
+    });
+
+    And("the handlers should have been triggered in correct order", () => {
+      result.should.eql([0, 1, 2]);
+    });
+    And("one should have been handled by unrecoverable handler", () => {
+      unrecoverable.length.should.eql(1);
+    });
+  });
 });

--- a/test/lib/recipes-repo-test.js
+++ b/test/lib/recipes-repo-test.js
@@ -102,6 +102,28 @@ describe("recipes-repo", () => {
       repo.processedKeys().should.eql(["event.baz.processed", "event.bar.processed", "event.unrecoverable.processed"]);
     });
   });
+
+  describe("processedUnrecoverableKeys", () => {
+    it("should return empty if no events", () => {
+      const nullRepo = recipesRepo.init([]);
+      nullRepo.processedUnrecoverableKeys().should.eql([]);
+    });
+
+    it("should return nothing if no events", () => {
+      const nullRepo = recipesRepo.init([], {"trigger.baz": passThru});
+      nullRepo.processedUnrecoverableKeys().should.eql([]);
+    });
+
+    it("should return each recipe key with an unrecoverable handler as keys", () => {
+      repo
+        .processedUnrecoverableKeys()
+        .should.eql([
+          "event.unrecoverable.validate.one.unrecoverable.processed",
+          "event.unrecoverable.event.baz.perform.one.unrecoverable.processed",
+          "event.unrecoverable.perform.two.unrecoverable.processed"
+        ]);
+    });
+  });
   describe("first", () => {
     it("should return empty if no events", () => {
       const nullRepo = recipesRepo.init([]);


### PR DESCRIPTION
- If a spawned child is unrecoverable we want to treat it as processed.
- recipe-repo can return all processed unrecoverable kyes.
- Let the internal handler subcribe to all unrecoverable processed keys so they are treated as a done child if spawned.