### PR TITLE
Make useParentCorrelationId explicitly false per default

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const publishCli = require("./publish-cli");
 const shutdownHandler = require("./lib/graceful-shutdown");
 let server;
 
-function start({recipes, triggers, useParentCorrelationId}) {
+function start({recipes, triggers, useParentCorrelationId = false}) {
   logger.info(`Using ${brokerBackend} as lu-broker backend`);
   if (!config.disableGracefulShutdown) {
     shutdownHandler.init();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-broker",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "engines": {
     "node": ">=12 <=16"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-broker",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "engines": {
     "node": ">=12 <=16"
   },


### PR DESCRIPTION
Makes the vscode typechecker stop complaining about mismatching arguments.